### PR TITLE
Adding CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+### THDC, Mustang Website
+
+## Getting Started
+
+- Steps for those with commit access:
+
+1. Clone the repository.
+2. Create a feature branch.
+3. Make your changes in the feature branch.
+4. Commit the feature branch.
+Open a pull request to merge the feature branch into the gh-pages branch.
+6. Resolve any conflicts if necessary, then merge your feature branch.
+
+- Steps for those without commit access:
+
+1. Fork the repository.
+2. Make your changes in your fork.
+3. Commit the changes to your fork.
+4. Open a pull request to merge your fork into the upstream repository.
+
+
+Feel free to ping @MegaMind98 with any questions you may have.

--- a/README.md
+++ b/README.md
@@ -38,24 +38,7 @@ pages when you edit the source files.
 
 ## Contributing
 
-Steps for those *with* commit access:
-
-1. Clone the repository.
-2. Create a feature branch.
-3. Make your changes in the feature branch.
-4. Commit the feature branch.
-5. Open a pull request to merge the feature branch into the gh-pages branch.
-6. Resolve any conflicts if necessary, then merge your feature branch.
-
-Steps for those *without* commit access:
-
-1. Fork the repository.
-2. Make your changes in your fork.
-3. Commit the changes to your fork.
-4. Open a pull request to merge your fork into the upstream repository.
-
-Feel free to ping [@MegaMind98](https://github.com/MegaMind98) with any questions you
-may have.
+See [CONTRIBUTING.md] (https://github.com/tminussi/np/blob/master/CONTRIBUTING.md)
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pages when you edit the source files.
 
 ## Contributing
 
-See [CONTRIBUTING.md] (https://github.com/tminussi/np/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/tminussi/np/blob/master/CONTRIBUTING.md)
 
 ## Feedback
 


### PR DESCRIPTION
This relates to #3

Rather than having the contribution guidelines on the README.md itself, I think it's worth putting these instructions on its own file, therefore I created the CONTRIBUTING.md and changed the README to point to that file.

It is now cleaner where to find things. Hope you like it.